### PR TITLE
Add register and address to account data

### DIFF
--- a/react/queries/account.gql
+++ b/react/queries/account.gql
@@ -33,5 +33,14 @@ query getAccount {
       }
       position
     }
+    register
+    address {
+      addressLine1
+      addressLine2
+      city
+      zipCode
+      country
+      state
+    }
   }
 }


### PR DESCRIPTION
#### What is the purpose of this pull request?
<!--- Describe your changes in detail. -->
Make `address` and `register` available on the frontend.
Related to https://app.clubhouse.io/vtex/story/37764/inserir-dados-de-empresa-no-rodap%C3%A9-da-loja
Depends on https://github.com/vtex-gocommerce/accounts-graphql/pull/15

#### What problem is this solving?
<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?
Check for the account context here:
https://augusto--gc-cli6734.mygocommerce.com/

#### Screenshots or example usage

#### Types of changes

- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
